### PR TITLE
beryllium: rootdir: Give proper permissions for /dev/diag

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -62,6 +62,9 @@ on init
     chown root system /sys/fs/cgroup/memory/bg/tasks
     chmod 0660 /sys/fs/cgroup/memory/bg/tasks
 
+    # Change permissions for /dev/diag
+    chmod 0666 /dev/diag
+
 on post-fs
     chmod 0755 /sys/kernel/debug/tracing
     chmod 0660 /sys/class/leds/red/brightness


### PR DESCRIPTION
* This gives proper permission to /dev/diag node so that diag driver can load successfully

* Logs spam with error '-13' which basically translates to access denied/invalid permission.

* Fix this by giving system read and write access.

Before in log:
Diag_Lib:  Diag_LSM_Init: Failed to open handle to diag driver, error = 13 06-25 12:53:39.868  3101  3101 I Nvram_btwifi: Diag_LSM_Init() failed.

Change-Id: I87fe322e7c0d91a494d29213e6f657ed8a7032a6